### PR TITLE
Add support for retrieving a map of torrents.

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,6 +168,22 @@ func (c *Client) GetTorrents() ([]*Torrent, error) {
 	return t, nil
 }
 
+// GetTorrentMap returns a map of torrents indexed by torrent hash.
+func (c *Client) GetTorrentMap() (TorrentMap, error) {
+	torrents, err := c.GetTorrents()
+	if err != nil {
+		return nil, err
+	}
+
+	tm := make(TorrentMap)
+
+	for _, t := range torrents {
+		tm[t.HashString] = t
+	}
+
+	return tm, nil
+}
+
 // Add shortcut for Client.AddTorrent
 func (c *Client) Add(filename string) (*Torrent, error) {
 	args := AddTorrentArg{

--- a/torrent.go
+++ b/torrent.go
@@ -93,6 +93,9 @@ type Torrents struct {
 	Torrents []*Torrent `json:"torrents"`
 }
 
+// TorrentMap is a map of Torrents indexed by torrent hash.
+type TorrentMap map[string]*Torrent
+
 // SetTorrentArg arguments for Torrent.Set method
 type SetTorrentArg struct {
 	BandwidthPriority   int      `json:"bandwidthPriority,omitempty"`


### PR DESCRIPTION
I added support for retrieving a map of torrents to better support [invocation upon torrent completion](https://trac.transmissionbt.com/wiki/Scripts#OnTorrentCompletion).  The torrent map is indexed by the torrent hash.

This is more of a helper method.  I understand if you'd rather deny this PR.
