### PR TITLE
Fix case when session ID changes

### DIFF
--- a/client.go
+++ b/client.go
@@ -76,6 +76,12 @@ func (c *Client) Do(req *http.Request, retry bool) (*http.Response, error) {
 		req.SetBasicAuth(c.User, c.Password)
 	}
 	if c.sessionID != "" {
+		// Delete the previous session in header in case there was one
+
+		// We need to do this because the previous header won't be overridden
+		// by the "Add", we need to manually delete the previous header or the
+		// request will fail
+		req.Header.Del("X-Transmission-Session-Id")
 		req.Header.Add("X-Transmission-Session-Id", c.sessionID)
 	}
 


### PR DESCRIPTION
We used to Add the new SessionId to the header, but when the SessionId
changed, `header.Add` didn't override the previous one. We used to just
add a new header that wasn't taken into account by the server, creating
thus a second HTTP Conflict
We now manually delete the previous SessionId to be sure that the good
one is in place.