### PR TITLE
force 64 bit ints for raspbian support

### DIFF
--- a/session.go
+++ b/session.go
@@ -114,11 +114,11 @@ type Statictics struct {
 
 // StaticticDetail represent statictics details
 type StaticticDetail struct {
-	UploadedBytes   int
-	DownloadedBytes int
-	FilesAdded      int
-	SessionCount    int
-	SecondsActive   int
+	UploadedBytes   int64
+	DownloadedBytes int64
+	FilesAdded      int64
+	SessionCount    int64
+	SecondsActive   int64
 }
 
 // Units in session

--- a/torrent.go
+++ b/torrent.go
@@ -179,12 +179,12 @@ type Torrent struct {
 	SeedIdleMode            int
 	SeedRatioLimit          float64
 	SeedRatioMode           int
-	SizeWhenDone            int
+	SizeWhenDone            int64
 	StartDate               int
 	Status                  int
 	Trackers                *[]Trackers
 	TrackerStats            *[]TrackerStats
-	TotalSize               int
+	TotalSize               int64
 	TorrentFile             string
 	UploadedEver            int
 	UploadLimit             int
@@ -197,14 +197,14 @@ type Torrent struct {
 
 // File transmission API response
 type File struct {
-	BytesCompleted int
-	Length         int
+	BytesCompleted int64
+	Length         int64
 	Name           string
 }
 
 // FileStats transmission API response
 type FileStats struct {
-	BytesCompleted int
+	BytesCompleted int64
 	Wanted         bool
 	Priority       int
 }

--- a/torrent.go
+++ b/torrent.go
@@ -129,13 +129,13 @@ type Torrent struct {
 	AddedDate               int
 	BandwidthPriority       int
 	Comment                 string
-	CorruptEver             int
+	CorruptEver             int64
 	Creator                 string
 	DateCreated             int
-	DesiredAvailable        int
+	DesiredAvailable        int64
 	DoneDate                int
 	DownloadDir             string
-	DownloadedEver          int
+	DownloadedEver          int64
 	DownloadLimit           int
 	DownloadLimited         bool
 	Error                   int
@@ -145,14 +145,14 @@ type Torrent struct {
 	Files                   *[]File
 	FileStats               *[]FileStats
 	HashString              string
-	HaveUnchecked           int
-	HaveValid               int
+	HaveUnchecked           int64
+	HaveValid               int64
 	HonorsSessionLimits     bool
 	ID                      int
 	IsFinished              bool
 	IsPrivate               bool
 	IsStalled               bool
-	LeftUntilDone           int
+	LeftUntilDone           int64
 	MagnetLink              string
 	ManualAnnounceTime      int
 	MaxConnectedPeers       int
@@ -186,7 +186,7 @@ type Torrent struct {
 	TrackerStats            *[]TrackerStats
 	TotalSize               int64
 	TorrentFile             string
-	UploadedEver            int
+	UploadedEver            int64
 	UploadLimit             int
 	UploadLimited           bool
 	UploadRatio             float64

--- a/torrent.go
+++ b/torrent.go
@@ -129,13 +129,13 @@ type Torrent struct {
 	AddedDate               int
 	BandwidthPriority       int
 	Comment                 string
-	CorruptEver             int
+	CorruptEver             int64
 	Creator                 string
 	DateCreated             int
-	DesiredAvailable        int
+	DesiredAvailable        int64
 	DoneDate                int
 	DownloadDir             string
-	DownloadedEver          int
+	DownloadedEver          int64
 	DownloadLimit           int
 	DownloadLimited         bool
 	Error                   int
@@ -145,14 +145,14 @@ type Torrent struct {
 	Files                   *[]File
 	FileStats               *[]FileStats
 	HashString              string
-	HaveUnchecked           int
-	HaveValid               int
+	HaveUnchecked           int64
+	HaveValid               int64
 	HonorsSessionLimits     bool
 	ID                      int
 	IsFinished              bool
 	IsPrivate               bool
 	IsStalled               bool
-	LeftUntilDone           int
+	LeftUntilDone           int64
 	MagnetLink              string
 	ManualAnnounceTime      int
 	MaxConnectedPeers       int
@@ -179,14 +179,14 @@ type Torrent struct {
 	SeedIdleMode            int
 	SeedRatioLimit          float64
 	SeedRatioMode           int
-	SizeWhenDone            int
+	SizeWhenDone            int64
 	StartDate               int
 	Status                  int
 	Trackers                *[]Trackers
 	TrackerStats            *[]TrackerStats
-	TotalSize               int
+	TotalSize               int64
 	TorrentFile             string
-	UploadedEver            int
+	UploadedEver            int64
 	UploadLimit             int
 	UploadLimited           bool
 	UploadRatio             float64
@@ -197,14 +197,14 @@ type Torrent struct {
 
 // File transmission API response
 type File struct {
-	BytesCompleted int
-	Length         int
+	BytesCompleted int64
+	Length         int64
 	Name           string
 }
 
 // FileStats transmission API response
 type FileStats struct {
-	BytesCompleted int
+	BytesCompleted int64
 	Wanted         bool
 	Priority       int
 }


### PR DESCRIPTION
As raspberry PIs are still 32bit, I enforce 64bit integers so this library works for transmission-daemons running on PIs.