### PR TITLE
Basic auth can be used with only a username or password

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,7 +72,7 @@ type Response struct {
 // Do low level function for interact with transmission only take care of
 // authentification and session id
 func (c *Client) Do(req *http.Request, retry bool) (*http.Response, error) {
-	if c.User != "" && c.Password != "" {
+	if c.User != "" || c.Password != "" {
 		req.SetBasicAuth(c.User, c.Password)
 	}
 	if c.sessionID != "" {


### PR DESCRIPTION
On my own transmission instance I do not have a username set, so I log in with only a password. However with the old way of checking if basic auth was needed did not support this. 

I added an additional parameter to the config to force require authentication, since it is by default false it will not break the old implementation and just add new functionality if the parameter is set to true.