### PR TITLE
Add support for transmission v4

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -193,7 +193,7 @@ type Torrent struct {
 	UploadLimit             int
 	UploadLimited           bool
 	UploadRatio             float64
-	Wanted                  []int
+	Wanted                  []bool
 	Webseeds                []string
 	WebseedsSendingToUs     int
 }


### PR DESCRIPTION
on tranmission v4 wanted are now bool

i am not so sure how to make it backward compatible wth older versions (best would have to have go modules prefix but i guess that ship has sailed)...